### PR TITLE
Fix example in lua-filters docs. Fixes #4459

### DIFF
--- a/doc/lua-filters.md
+++ b/doc/lua-filters.md
@@ -351,7 +351,7 @@ local vars = {}
 function get_vars (meta)
   for k, v in pairs(meta) do
     if v.t == 'MetaInlines' then
-      vars["$" .. k .. "$"] = v
+      vars["$" .. k .. "$"] = {table.unpack(v)}
     end
   end
 end


### PR DESCRIPTION
Updates the example code so that the Macro Replacement example lua filter works. Fixed it by copying contents of the MetaInline (with table.unpack) rather than saving the MetaInline element directly.